### PR TITLE
Fixed vlibTemplate Error - file not found

### DIFF
--- a/usr/local/ispconfig/server/plugins-available/varnish_plugin.inc.php
+++ b/usr/local/ispconfig/server/plugins-available/varnish_plugin.inc.php
@@ -145,7 +145,7 @@ class varnish_plugin {
     		$app->load('tpl');
 
     		$tpl = new tpl();
-    		$tpl->newTemplate('varnish_plugin.conf.master');
+    		$tpl->newTemplate('varnish_plugin.vhost.conf.master');
 
             $tpl->setVar('domain', $data['new']['domain']);
 


### PR DESCRIPTION
vlibTemplate Error: Template (varnish_plugin.conf.master) file not found.
Corrected template name.